### PR TITLE
Salvar IQT na pasta Base

### DIFF
--- a/src/Iqt.py
+++ b/src/Iqt.py
@@ -125,8 +125,8 @@ def GerarIqt(app) -> list[str]:
         #atualiza km
         update_distances(sTemp, setup)
     
-        #salvar arquivo
-        out_dir = setup.iqt.Saida
+        #salvar arquivo na pasta Base
+        out_dir = os.path.join(setup.iqt.Saida, "Base")
         os.makedirs(out_dir, exist_ok=True)
 
         # 8) Monta o nome completo com extensão


### PR DESCRIPTION
## Sumário
- salva arquivos gerados do IQT dentro da subpasta `Base`

## Testes
- `python -m py_compile src/Iqt.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4acf785808332b3c1e9f2aa695e03