### PR TITLE
Normalize column comparison in Carregar

### DIFF
--- a/src/Leitor.py
+++ b/src/Leitor.py
@@ -29,8 +29,10 @@ class Leitor:
                     if ex(caminho):
 
                          temp_df = pd.read_excel(caminho,nrows=0) #cabecalho
+                         temp_cols = [c.strip().lower() for c in temp_df.columns]
+                         expected = [c.strip().lower() for c in settings.Coluna_padrao]
 
-                         if list(temp_df.columns) == getattr(settings,'Coluna_padrao'):
+                         if temp_cols == expected:
                               self.log(f'CARREGANDO {filial.upper()}')
                               locals()[filial] = pd.read_excel(caminho)
                               locals()[filial] = locals()[filial].drop(locals()[filial].index[-1])


### PR DESCRIPTION
## Summary
- Normalize column names from Excel and settings before comparison in `Leitor.Carregar`

## Testing
- `python -m py_compile src/Leitor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ade126f01c833287cbdf187c08e0f6