### PR TITLE
Clean IQT output directory logic

### DIFF
--- a/src/Iqt.py
+++ b/src/Iqt.py
@@ -125,14 +125,10 @@ def GerarIqt(app) -> list[str]:
         #atualiza km
         update_distances(sTemp, setup)
         
-        codex/fix-output-file-directory-for-iqt-l53j6c
         # salvar arquivo na pasta Base
         out_dir = os.path.normpath(setup.iqt.Saida)
         if os.path.basename(out_dir).lower() != "base":
             out_dir = os.path.join(out_dir, "Base")
-        #salvar arquivo na pasta Base
-        out_dir = os.path.join(setup.iqt.Saida, "Base")
-        main
         os.makedirs(out_dir, exist_ok=True)
 
         # 8) Monta o nome completo com extensão


### PR DESCRIPTION
## Summary
- remove leftover debug lines in IQT script
- simplify and normalize output directory creation

## Testing
- `python -m py_compile src/Iqt.py`


------
https://chatgpt.com/codex/tasks/task_e_68adec5baa788332b7ece9c88def5aac